### PR TITLE
Use temporary directory in testLoopNode script

### DIFF
--- a/testLoopNode.sh
+++ b/testLoopNode.sh
@@ -1,8 +1,11 @@
 set -e
 
+tmpdir="$(mktemp -d)"
+trap "rm -rf '$tmpdir'" EXIT
+
 while true
 do
-	node QuickHashGenTest.node.js >test.cpp
-	g++ -otest test.cpp
-	./test
+	node QuickHashGenTest.node.js >"$tmpdir/test.cpp"
+	g++ -o "$tmpdir/test" "$tmpdir/test.cpp"
+	"$tmpdir/test"
 done


### PR DESCRIPTION
## Summary
- Make `testLoopNode.sh` write test.cpp and compiled binary to a temporary directory that is cleaned up after execution

## Testing
- `timeout 5 bash testLoopNode.sh`

------
https://chatgpt.com/codex/tasks/task_e_68ace191e8f08332b8149dfb27a40562