### PR TITLE
Add seed option to CLI and golden file tests

### DIFF
--- a/QuickHashGenCLI.js
+++ b/QuickHashGenCLI.js
@@ -14,6 +14,7 @@ function printUsage() {
     console.error('  --eval-test              verify result using chosen engine');
     console.error('  --force-eval             use eval engine (if available)');
     console.error('  --bench                  benchmark eval vs Function engines');
+    console.error('  --seed N                seed the random generator');
     console.error('');
     console.error('Strings are read from [input-file] or stdin. Each line may be');
     console.error('plain text or one or more C-style quoted strings separated by');
@@ -47,6 +48,9 @@ for (let i = 0; i < args.length; ++i) {
         opts.forceEval = true;
     } else if (a === '--bench') {
         opts.bench = true;
+    } else if (a === '--seed' && i + 1 < args.length) {
+        const s0 = parseInt(args[++i], 10);
+        core.globalPRNG = new core.XorshiftPRNG2x32(s0);
     } else if (a[0] === '-') {
         printUsage();
         process.exit(1);

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Options:
   engine" checkbox and can influence performance depending on the environment.
 * `--bench` &ndash; run a simple benchmark comparing the `Function` constructor and
   `eval` engines after a solution is found.
+ * `--seed N` &ndash; seed the internal PRNG for deterministic output with a single
+   32-bit value.
 
 ### Input formats
 

--- a/test.cmd
+++ b/test.cmd
@@ -1,0 +1,15 @@
+@echo off
+setlocal
+
+node QuickHashGenCLI.js --seed 1 --tests 100 tests\input1.txt > tests\out1.c
+if errorlevel 1 exit /b 1
+fc tests\out1.c tests\golden1.c > nul
+if errorlevel 1 exit /b 1
+node QuickHashGenCLI.js --seed 123 --tests 100 tests\input2.txt > tests\out2.c
+if errorlevel 1 exit /b 1
+fc tests\out2.c tests\golden2.c > nul
+if errorlevel 1 exit /b 1
+
+del tests\out1.c tests\out2.c
+
+echo All tests passed.

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+node QuickHashGenCLI.js --seed 1 --tests 100 tests/input1.txt > tests/out1.c
+node QuickHashGenCLI.js --seed 123 --tests 100 tests/input2.txt > tests/out2.c
+
+diff -u tests/golden1.c tests/out1.c
+rm tests/out1.c
+
+diff -u tests/golden2.c tests/out2.c
+rm tests/out2.c
+
+echo "All tests passed."

--- a/tests/golden1.c
+++ b/tests/golden1.c
@@ -1,0 +1,12 @@
+/* Built with QuickHashGen CLI */
+static int lookup(int n /* string length */, const char* s /* string (zero terminated) */) {
+	static const char* STRINGS[3] = {
+		"red", "green", "blue"
+	};
+	static const int HASH_TABLE[4] = {
+		2, 1, -1, 0
+	};
+	if (n < 3 || n > 5) return -1;
+	int stringIndex = HASH_TABLE[(n) & 3];
+	return (stringIndex >= 0 && strcmp(s, STRINGS[stringIndex]) == 0) ? stringIndex : -1;
+}

--- a/tests/golden2.c
+++ b/tests/golden2.c
@@ -1,0 +1,12 @@
+/* Built with QuickHashGen CLI */
+static int lookup(int n /* string length */, const char* s /* string (zero terminated) */) {
+	static const char* STRINGS[4] = {
+		"black", "white", "blue", "yellow"
+	};
+	static const int HASH_TABLE[16] = {
+		-1, 0, -1, -1, -1, 2, -1, -1, -1, 1, -1, -1, 3, -1, -1, -1
+	};
+	if (n < 4 || n > 6) return -1;
+	int stringIndex = HASH_TABLE[(s[2]) & 15];
+	return (stringIndex >= 0 && strcmp(s, STRINGS[stringIndex]) == 0) ? stringIndex : -1;
+}

--- a/tests/input1.txt
+++ b/tests/input1.txt
@@ -1,0 +1,3 @@
+red
+green
+blue

--- a/tests/input2.txt
+++ b/tests/input2.txt
@@ -1,0 +1,4 @@
+black
+white
+blue
+yellow


### PR DESCRIPTION
## Summary
- allow seeding the PRNG with `--seed` for deterministic output
- document the new CLI flag
- add cross-platform scripts that check generated code against golden files

## Testing
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ad87a16f788332b1320d38e0f149b0