### PR TITLE
Limit benchmark runtime

### DIFF
--- a/QuickHashGenCLI.js
+++ b/QuickHashGenCLI.js
@@ -137,11 +137,13 @@ if (opts.bench) {
     let fnEval = eval('(function(n,w){return ' + expr + ';})');
     let fnFunc = evalObj.fn;
     let ITERS = 100000;
-    while (true) {
+    const MAX_ITERS = 10000000;
+    const TARGET_MS = 100;
+    while (ITERS < MAX_ITERS) {
         let t0 = Date.now();
         for (let i = 0; i < ITERS; ++i) fnEval(n, arr);
         let t = Date.now() - t0;
-        if (t >= 250) break;
+        if (t >= TARGET_MS) break;
         ITERS *= 2;
     }
     // warm up functional engine


### PR DESCRIPTION
## Summary
- cap benchmark iterations and target time so `--bench` finishes promptly

## Testing
- `node QuickHashGenCLI.js --bench tests/input1.txt`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ad989638408332ae1360df497234a2