### PR TITLE
Ensure deterministic seeded test loops and validate JS generators

### DIFF
--- a/testLoopNode.sh
+++ b/testLoopNode.sh
@@ -3,9 +3,12 @@ set -e
 tmpdir="$(mktemp -d)"
 trap "rm -rf '$tmpdir'" EXIT
 
+seed=1
 while true
 do
-	node QuickHashGenTest.node.js >"$tmpdir/test.cpp"
-	g++ -o "$tmpdir/test" "$tmpdir/test.cpp"
-	"$tmpdir/test"
+        echo "seed $seed"
+        node QuickHashGenTest.node.js "$seed" >"$tmpdir/test.cpp"
+        g++ -o "$tmpdir/test" "$tmpdir/test.cpp"
+        "$tmpdir/test"
+        seed=$((seed+1))
 done


### PR DESCRIPTION
## Summary
- Allow `QuickHashGenTest.node.js` to take a seed and verify generated JS hash expression and evaluator before emitting C++.
- Run `testLoopNode.sh` with incrementing seeds and display each seed while testing the generated code.

## Testing
- `node QuickHashGenTest.node.js 2 > /tmp/test.cpp && g++ -o /tmp/test /tmp/test.cpp && /tmp/test | head -n 5`
- `timeout 3 bash testLoopNode.sh`


------
https://chatgpt.com/codex/tasks/task_e_68adb474aa54833298f58be6c361d2d9