### PR TITLE
refactor: hide internal PRNG behind randomInt

### DIFF
--- a/NewQuickHashMaker.html
+++ b/NewQuickHashMaker.html
@@ -165,16 +165,20 @@ line
 		this.nextInt = function(max){ next(); return (py >>> 0) % max; };
 		this.clone = function(){ return new XorshiftPRNG2x32(px, py); };
 	}
-	var globalPRNG = new XorshiftPRNG2x32();
-	if (!("imul" in Math)) { Math.imul = function(a,b){ var ah=(a>>>16)&0xffff, al=a&0xffff, bh=(b>>>16)&0xffff, bl=b&0xffff; return ((al*bl)+(((ah*bl+al*bh)<<16)>>>0)|0); }; }
+        if (!("imul" in Math)) { Math.imul = function(a,b){ var ah=(a>>>16)&0xffff, al=a&0xffff, bh=(b>>>16)&0xffff, bl=b&0xffff; return ((al*bl)+(((ah*bl+al*bh)<<16)>>>0)|0); }; }
 
 	// ===== Eval detection =====
 	var EVAL_ALLOWED = false;
 	function detectEvalAllowed(){ try{ var f=eval("(function(n,w){return (n|0)+(w[0]|0);})"); return f(1,[2])===3; }catch(_){ return false; } }
 
 	// ===== Core generator (no eval; CSP-safe) =====
-	function QuickHashMaker(strings, minTableSize, maxTableSize, zeroTerminated, allowMultiplication, allowLength) {
-		var stringSet = { }, maxLength = 0, minLength = 0x7fffffff;
+        function QuickHashMaker(strings, minTableSize, maxTableSize, zeroTerminated, allowMultiplication, allowLength, seed0, seed1) {
+                var stringSet = { }, maxLength = 0, minLength = 0x7fffffff;
+
+                if (typeof seed0 === "undefined") { seed0 = (Math.random()*0x100000000)>>>0; seed1 = (Math.random()*0x100000000)>>>0; }
+                else if (typeof seed1 === "undefined") { seed1 = 362436069; }
+                var prng = new XorshiftPRNG2x32(seed0, seed1);
+                this.randomInt = function(max){ return prng.nextInt(max); };
 		for (var i = 0; i < strings.length; ++i) {
 			var s = strings[i];
 			if (s in stringSet) throw new Error("Duplicate string: " + escapeCString(s));
@@ -240,9 +244,10 @@ line
 			if (DEBUG) { assert(complexity > 0, "complexity>0"); assert((minTableSize|0)===minTableSize && (minTableSize & (minTableSize-1))===0, "minSize pow2"); assert((maxTableSize|0)===maxTableSize && (maxTableSize & (maxTableSize-1))===0, "maxSize pow2"); }
 			if (!(complexity in tried)) tried[complexity] = {};
 			var stringsCount = strings.length; var hashes = new Array(stringsCount);
-			for (var i = 0; i < iterations; ++i) {
-				var prngCopy = globalPRNG.clone();
-				var exprObj = generateRandomExpression(globalPRNG, complexity, maxTableSize - 1, false, false);
+                var rnd = prng;
+                for (var i = 0; i < iterations; ++i) {
+                                var prngCopy = rnd.clone();
+                                var exprObj = generateRandomExpression(rnd, complexity, maxTableSize - 1, false, false);
 				var expr = exprObj.js;
 				if (complexity >= 4 || !(expr in tried[complexity])) {
 					if (complexity < 4) tried[complexity][expr] = true;
@@ -556,7 +561,7 @@ line
 			if (theHashMaker !== null) {
 				var timeOut = Date.now() + 100;
 				while (Date.now() - timeOut < 0) {
-					var complexity = globalPRNG.nextInt((best === null ? 32 : best.complexity)) + 1;
+                        var complexity = theHashMaker.randomInt((best === null ? 32 : best.complexity)) + 1;
 					var iters = Math.max(200 / strings.length, 1);
 					var found = theHashMaker.search(complexity, iters);
 					if (found !== null) {

--- a/QuickHashGenApp.js
+++ b/QuickHashGenApp.js
@@ -649,8 +649,8 @@ function intervalFunction() {
 		if (theHashMaker !== null) {
 			var timeOut = Date.now() + 100;
 			while (Date.now() - timeOut < 0) {
-				var complexity =
-					globalPRNG.nextInt(best === null ? 32 : best.complexity) + 1;
+                                var complexity =
+                                        theHashMaker.randomInt(best === null ? 32 : best.complexity) + 1;
 				var iters = Math.max(200 / strings.length, 1);
 				var found = theHashMaker.search(complexity, iters);
 				if (found !== null) {

--- a/QuickHashGenTest.node.js
+++ b/QuickHashGenTest.node.js
@@ -1,7 +1,6 @@
 var quickHashGen = require('./QuickHashGenCore');
 
 var QuickHashGen = quickHashGen.QuickHashGen;
-var globalPRNG = quickHashGen.globalPRNG;
 var XorshiftPRNG2x32 = quickHashGen.XorshiftPRNG2x32;
 
 var MAX_COMPLEXITY = 32;
@@ -72,7 +71,7 @@ var theHashMaker = new QuickHashGen(strings, minSize, maxSize, true, true, true)
 
 var found = null;
 while (found === null) {
-        var complexity = globalPRNG.nextInt(MAX_COMPLEXITY) + 1;
+        var complexity = theHashMaker.randomInt(MAX_COMPLEXITY) + 1;
         found = theHashMaker.search(complexity, 100000);
 }
 

--- a/README.md
+++ b/README.md
@@ -149,11 +149,14 @@ class for programmatic integration:
 
 * **`QuickHashGen`** – the core search engine. The constructor accepts
   `(strings, minTableSize, maxTableSize, zeroTerminated,
-  allowMultiplication, allowLength, useEvalEngine=false)`.
-  Methods include:
-  * `search(complexity, iterations)` – explore random expressions and return
-    the first collision-free solution or `null`.
-  * `getTestedCount()` – total number of expressions evaluated so far.
+  allowMultiplication, allowLength, useEvalEngine=false, seed0?, seed1?)`.
+  If `seed0` is omitted the PRNG is seeded randomly; providing `seed0`
+  (and optionally `seed1`) yields deterministic output.
+    Methods include:
+    * `search(complexity, iterations)` – explore random expressions and return
+      the first collision-free solution or `null`.
+    * `getTestedCount()` – total number of expressions evaluated so far.
+    * `randomInt(max)` – draw a pseudo-random integer in `[0, max)`.
     * `generateCExpression(solution)` – build a C hash expression string.
     * `generateJSExpression(solution)` – build a JavaScript hash expression string.
     * `generateJSEvaluator(solution)` – build a CSP‑safe evaluator function.
@@ -168,8 +171,8 @@ class for programmatic integration:
   string.
 * **`parseCString`** / **`escapeCString`** – convert between C‑style quoted
   strings and raw JavaScript strings.
-* **`XorshiftPRNG2x32`** and **`globalPRNG`** – deterministic pseudo‑random
-  number generators used during the search.
+* **`XorshiftPRNG2x32`** – deterministic pseudo‑random number generator used
+  during the search.
 
 ## Browser interface
 


### PR DESCRIPTION
## Summary
- encapsulate QuickHashGen's RNG with a `randomInt` helper instead of exposing `.prng`
- update browser app, sample HTML, and tests to use the new helper
- document `randomInt` in README

## Testing
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68adb93244888332900dfe8bfc17b52a