### PR TITLE
Fix unsigned right shift in generated C expressions

### DIFF
--- a/QuickHashGenCore.js
+++ b/QuickHashGenCore.js
@@ -293,7 +293,7 @@ function QuickHashGen(strings, minTableSize, maxTableSize, zeroTerminated, allow
                                return {prec:1, c:c, js:j, fn:function(n,w){ var v=a.fn(n,w)|0; return (v<<shamt)|0; }};
                        } else {
                                j = wrapJ(a,1)+' >>> '+shamt;
-                               c = wrapC(a,1)+' >> '+shamt;
+                               c = '(0u + '+wrapC(a,1)+') >> '+shamt;
                                return {prec:1, c:c, js:j, fn:function(n,w){ var v=a.fn(n,w)|0; return (v>>>shamt)|0; }};
                        }
                }

--- a/tests/golden3.c
+++ b/tests/golden3.c
@@ -26,6 +26,6 @@ static int lookup(int n /* string length */, const char* s /* string (zero termi
 	};
 	const unsigned char* p = (const unsigned char*) s;
 	if (n < 5 || n > 40) return -1;
-	int stringIndex = HASH_TABLE[(((0u + (p[2] ^ p[4]) - p[1]) << 5) + ((0u + ((p[0] ^ (39 < n ? p[39] : 0)) * 100u + n - n - (p[3] - (n >> 20))) * (n + 90u - p[5]) * (p[2] ^ 191u)) << 6 >> 10)) & 255u];
+	int stringIndex = HASH_TABLE[(((0u + (p[2] ^ p[4]) - p[1]) << 5) + ((0u + (0u + ((p[0] ^ (39 < n ? p[39] : 0)) * 100u + n - n - (p[3] - ((0u + n) >> 20))) * (n + 90u - p[5]) * (p[2] ^ 191u)) << 6) >> 10)) & 255u];
 	return (stringIndex >= 0 && strcmp(s, STRINGS[stringIndex]) == 0) ? stringIndex : -1;
 }


### PR DESCRIPTION
## Summary
- ensure generated C right shifts operate on unsigned values so JS and C agree
- update golden3 test fixture for unsigned shift semantics

## Testing
- `bash test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68adc3afb8b483329658ed930224f672