### PR TITLE
Validate numeric CLI option values

### DIFF
--- a/QuickHashGenCLI.js
+++ b/QuickHashGenCLI.js
@@ -36,6 +36,10 @@ for (let i = 0; i < args.length; ++i) {
     const a = args[i];
     if (a === '--tests' && i + 1 < args.length) {
         opts.tests = parseInt(args[++i], 10);
+        if (!Number.isFinite(opts.tests) || opts.tests < 0) {
+            printUsage();
+            process.exit(1);
+        }
     } else if (a === '--no-multiplications') {
         opts.allowMultiplications = false;
     } else if (a === '--no-length') {
@@ -50,6 +54,10 @@ for (let i = 0; i < args.length; ++i) {
         opts.bench = true;
     } else if (a === '--seed' && i + 1 < args.length) {
         opts.seed = parseInt(args[++i], 10);
+        if (!Number.isFinite(opts.seed) || opts.seed < 0) {
+            printUsage();
+            process.exit(1);
+        }
     } else if (a[0] === '-') {
         printUsage();
         process.exit(1);

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,23 @@
 set -e
 
 node QuickHashGenCLI.js --seed 1 --tests 100 tests/input1.txt > tests/out1.c
+# invalid option values should print usage and fail
+if node QuickHashGenCLI.js --tests -1 tests/input1.txt >/dev/null 2>tests/err.log; then
+    echo "Expected failure for --tests -1" >&2
+    rm tests/err.log
+    exit 1
+fi
+grep -q 'Usage:' tests/err.log
+rm tests/err.log
+
+if node QuickHashGenCLI.js --seed foo tests/input1.txt >/dev/null 2>tests/err.log; then
+    echo "Expected failure for --seed foo" >&2
+    rm tests/err.log
+    exit 1
+fi
+grep -q 'Usage:' tests/err.log
+rm tests/err.log
+
 # verify option handling
 node QuickHashGenCLI.js --seed 1 --tests 100 --force-eval --eval-test tests/input1.txt > tests/out1_eval.c
 node QuickHashGenCLI.js --seed 123 --tests 100 tests/input2.txt > tests/out2.c


### PR DESCRIPTION
## Summary
- Ensure `--tests` and `--seed` options accept only finite, non-negative integers
- Add regression tests verifying invalid option values print usage and exit non-zero

## Testing
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aebf118d7c83329d05db06aecee698