### PR TITLE
feat: allow environment-driven debug

### DIFF
--- a/QuickHashGenCore.js
+++ b/QuickHashGenCore.js
@@ -1,7 +1,8 @@
 "use strict";
 // Core hashing algorithm extracted for reuse in browser and CLI tools.
 
-var DEBUG = true;
+// Enable debug assertions by setting NODE_ENV=development.
+var DEBUG = typeof process !== 'undefined' && process && process.env && process.env.NODE_ENV === 'development';
 
 var assert;
 if (DEBUG) {
@@ -154,14 +155,13 @@ function escapeCString(s) {
 	return o;
 }
 
-// Q & D test
-
 if (DEBUG) {
-	var p = parseCString('"ab\\0cdef\\\\gjio\\n\\\r\nx\\x45\\u0045\\u0123\\?\\053\\1012end"slack');
-	assert(p[0] === "ab\0cdef\\gjio\nxEE\u0123?+A2end" && p[1] === 52);
-	assert(escapeCString("hej \n \x22''\\ \x04 \u2414 \0 \r du") === "\"hej \\n \\\"''\\\\ \\x04 \\u2414 \\0 \\r du\"");
-	assert(escapeCString("\x050018efgef") === '"\\x05\\x30\\x30\\x31\\x38\\x65\\x66gef"'); // \x in C++ is greedy (stupid)
-	assert(escapeCString("\u050018efgef") === '"\\u050018efgef"'); // \u isn't greedy
+        // Quick-and-dirty tests
+        var p = parseCString('"ab\\0cdef\\\\gjio\\n\\\r\nx\\x45\\u0045\\u0123\\?\\053\\1012end"slack');
+        assert(p[0] === "ab\0cdef\\gjio\nxEE\u0123?+A2end" && p[1] === 52);
+        assert(escapeCString("hej \n \x22''\\ \x04 \u2414 \0 \r du") === "\"hej \\n \\\"''\\\\ \\x04 \\u2414 \\0 \\r du\"");
+        assert(escapeCString("\x050018efgef") === '"\\x05\\x30\\x30\\x31\\x38\\x65\\x66gef"'); // \x in C++ is greedy (stupid)
+        assert(escapeCString("\u050018efgef") === '"\\u050018efgef"'); // \u isn't greedy
 }
 
 function stringListToC(strings, maxCols, pre) {

--- a/README.md
+++ b/README.md
@@ -178,6 +178,20 @@ class for programmatic integration:
 * **`XorshiftPRNG2x32`** – deterministic pseudo‑random number generator used
   during the search.
 
+### Debug mode
+
+The core library includes a lightweight assertion helper and a few
+quick self-tests that run only when debug mode is enabled. To enable
+debugging during development, set the `NODE_ENV` environment variable
+to `development` before executing any scripts. For example:
+
+```
+NODE_ENV=development node QuickHashGenCLI.js --help
+```
+
+With `NODE_ENV` unset or set to `production`, these assertions and tests
+are skipped.
+
 ## Browser interface
 
 `QuickHashGen.html` offers an interactive front end. The single text area


### PR DESCRIPTION
## Summary
- derive DEBUG flag from `NODE_ENV` and guard internal tests
- document enabling debug mode via `NODE_ENV`

## Testing
- `./test.sh`
- `node -e "const core = require('./QuickHashGenCore'); core.assert(false, 'msg'); console.log('done');"`
- `NODE_ENV=development node -e "const core = require('./QuickHashGenCore'); try { core.assert(false, 'fail'); console.log('no throw'); } catch (e) { console.log('threw'); }"`


------
https://chatgpt.com/codex/tasks/task_e_68aebf10bf7c83328318fb62a17fac87