### PR TITLE
Declare hash variable before search loop

### DIFF
--- a/QuickHashGenCore.js
+++ b/QuickHashGenCore.js
@@ -412,6 +412,7 @@ function QuickHashGen(strings, minTableSize, maxTableSize, zeroTerminated, allow
 				var found = false;
 				while (!found && tableSize <= maxTableSize) {
 					var j = 0;
+					var hash;
 					while (j < stringsCount && collisions[hash = (hashes[j] & (tableSize - 1))] !== counter) {
 						collisions[hash] = counter;
 						++j;
@@ -423,19 +424,19 @@ function QuickHashGen(strings, minTableSize, maxTableSize, zeroTerminated, allow
 						tableSize <<= 1;
 					}
 				}
-								
-                                if (found) {
-                                        var table = new Array(tableSize);
-                                        for (var j = 0; j < tableSize; ++j) table[j] = -1;
-                                        for (var j = 0; j < stringsCount; ++j) {
-                                                var hash = func(strings[j].length, stringChars[j]) & (tableSize - 1);
-                                                if (DEBUG) assert(table[hash] === -1, "table[hash] === -1");
-                                                table[hash] = j;
-                                        }
-                                        var result = { "complexity":complexity, "prng":prngCopy, "table":table, "hashes":hashes };
-                                        if (evalTest) result.evalInfo = verifyEval(result);
-                                        return result;
-                                }
+
+				if (found) {
+					var table = new Array(tableSize);
+					for (var j = 0; j < tableSize; ++j) table[j] = -1;
+					for (var j = 0; j < stringsCount; ++j) {
+						var hash = func(strings[j].length, stringChars[j]) & (tableSize - 1);
+						if (DEBUG) assert(table[hash] === -1, "table[hash] === -1");
+						table[hash] = j;
+					}
+					var result = { "complexity":complexity, "prng":prngCopy, "table":table, "hashes":hashes };
+					if (evalTest) result.evalInfo = verifyEval(result);
+					return result;
+				}
 			}
 		}
 		return null;


### PR DESCRIPTION
## Summary
- define `hash` variable before the inner collision-checking loop in `search`
- normalize indentation for the `search` loop block

## Testing
- `node --check QuickHashGenCore.js`
- `./test.sh`
- `npx eslint@8 QuickHashGenCore.js --no-eslintrc --rule 'no-undef: error'` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aebf0fd3248332864e8ea5c1348058