### PR TITLE
Add CLI help flag

### DIFF
--- a/QuickHashGenCLI.js
+++ b/QuickHashGenCLI.js
@@ -7,6 +7,7 @@ const core = require('./QuickHashGenCore');
 function printUsage() {
     console.error('Usage: node QuickHashGenCLI.js [options] [input-file]');
     console.error('Options:');
+    console.error('  -h, --help              show usage information');
     console.error('  --tests N                number of expressions to try (default 100000)');
     console.error('  --no-multiplications     disallow multiplications');
     console.error('  --no-length              disallow use of n (string length)');
@@ -34,7 +35,10 @@ let opts = {
 let inputFile = null;
 for (let i = 0; i < args.length; ++i) {
     const a = args[i];
-    if (a === '--tests' && i + 1 < args.length) {
+    if (a === '--help' || a === '-h') {
+        printUsage();
+        process.exit(0);
+    } else if (a === '--tests' && i + 1 < args.length) {
         opts.tests = parseInt(args[++i], 10);
         if (!Number.isFinite(opts.tests) || opts.tests < 0) {
             printUsage();

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ node QuickHashGenCLI.js [options] [input-file]
 
 Options:
 
+* `-h`, `--help` &ndash; display usage information.
 * `--tests N` &ndash; number of expressions to try (default `100000`). A larger value
   increases the search space and the odds of discovering a lower-complexity hash
   at the cost of longer runtime.

--- a/test.cmd
+++ b/test.cmd
@@ -1,6 +1,12 @@
 @echo off
 setlocal
 
+node QuickHashGenCLI.js --help > tests\help.log 2>&1
+findstr /R /C:"Usage:" tests\help.log >nul || exit /b 1
+node QuickHashGenCLI.js -h > tests\help.log 2>&1
+findstr /R /C:"Usage:" tests\help.log >nul || exit /b 1
+del tests\help.log
+
 node QuickHashGenCLI.js --seed 1 --tests 100 tests\input1.txt > tests\out1.c
 node QuickHashGenCLI.js --seed 1 --tests 100 --force-eval --eval-test tests\input1.txt > tests\out1_eval.c
 if errorlevel 1 exit /b 1

--- a/test.sh
+++ b/test.sh
@@ -4,6 +4,13 @@ set -e
 node tests/parseQuickHashGenInput.test.js
 
 node QuickHashGenCLI.js --seed 1 --tests 100 tests/input1.txt > tests/out1.c
+# help flag should print usage and succeed
+node QuickHashGenCLI.js --help >tests/help.log 2>&1
+grep -q 'Usage:' tests/help.log
+rm tests/help.log
+node QuickHashGenCLI.js -h >tests/help.log 2>&1
+grep -q 'Usage:' tests/help.log
+rm tests/help.log
 # invalid option values should print usage and fail
 if node QuickHashGenCLI.js --tests -1 tests/input1.txt >/dev/null 2>tests/err.log; then
     echo "Expected failure for --tests -1" >&2


### PR DESCRIPTION
## Summary
- Add `-h`/`--help` flag to the CLI
- Document help flag in CLI usage and README
- Cover help flag behavior in test scripts

## Testing
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aecb786c088332a1b7f8c57c9d395b