### PR TITLE
Add deterministic search and CLI tests

### DIFF
--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -1,0 +1,25 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const cli = path.join(__dirname, '..', 'QuickHashGenCLI.js');
+
+function runCli(args) {
+    return execFileSync('node', [cli].concat(args), { encoding: 'utf8' });
+}
+
+const out1 = runCli(['--seed', '1', path.join(__dirname, 'input1.txt')]);
+const golden1 = fs.readFileSync(path.join(__dirname, 'golden1.c'), 'utf8');
+assert.strictEqual(out1, golden1);
+console.log('CLI golden1 test passed');
+
+const out2 = runCli(['--seed', '123', path.join(__dirname, 'input2.txt')]);
+const golden2 = fs.readFileSync(path.join(__dirname, 'golden2.c'), 'utf8');
+assert.strictEqual(out2, golden2);
+console.log('CLI golden2 test passed');
+
+const outNZ = runCli(['--seed', '1', '--tests', '10', '--no-zero-termination', path.join(__dirname, 'input1.txt')]);
+assert(outNZ.includes('zero termination not required'));
+assert(outNZ.includes('strncmp'));
+console.log('CLI zero-termination toggle test passed');

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -1,0 +1,60 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const core = require('../QuickHashGenCore');
+
+function nextPow2(n) {
+    let s = 1;
+    while (n > s) s <<= 1;
+    return s;
+}
+
+const inputPath = path.join(__dirname, 'input1.txt');
+const strings = core.parseQuickHashGenInput(fs.readFileSync(inputPath, 'utf8'));
+const minSize = nextPow2(strings.length);
+const maxSize = minSize * 8;
+const seed = 1;
+
+function findSolution(zeroTerminated) {
+    const qh = new core.QuickHashGen(strings, minSize, maxSize, zeroTerminated, true, true, false, false, seed);
+    const complexityRng = new core.XorshiftPRNG2x32(seed);
+    let best = null;
+    const tests = 1000;
+    while (qh.getTestedCount() < tests) {
+        const complexity = complexityRng.nextInt(best === null ? 32 : best.complexity) + 1;
+        const remaining = tests - qh.getTestedCount();
+        const iters = Math.max(1, Math.min(remaining, Math.floor(200 / strings.length)));
+        const found = qh.search(complexity, iters);
+        if (found && (best === null || found.complexity < best.complexity || (found.complexity === best.complexity && found.table.length < best.table.length))) {
+            best = found;
+            if (best.complexity === 1) break;
+        }
+    }
+    return { qh, best };
+}
+
+const expr1 = (() => { const { qh, best } = findSolution(true); return qh.generateCExpression(best); })();
+const expr2 = (() => { const { qh, best } = findSolution(true); return qh.generateCExpression(best); })();
+assert.strictEqual(expr1, expr2);
+
+const golden1 = fs.readFileSync(path.join(__dirname, 'golden1.c'), 'utf8');
+const match = golden1.match(/HASH_TABLE\[(.*)\];/);
+assert(match, 'hash expression not found');
+assert.strictEqual(expr1, match[1]);
+console.log('search deterministic seeding and generateCExpression test passed');
+
+const dupStrings = ['dup', 'dup'];
+const minDup = nextPow2(dupStrings.length);
+const maxDup = minDup * 8;
+let dupThrown = false;
+try {
+    new core.QuickHashGen(dupStrings, minDup, maxDup, true, true, true, false, false, seed);
+} catch (e) {
+    dupThrown = true;
+}
+assert(dupThrown);
+console.log('search duplicate strings test passed');
+
+const { best: nzBest } = findSolution(false);
+assert(nzBest !== null);
+console.log('search zero-termination toggle test passed');


### PR DESCRIPTION
## Summary
- add search tests for deterministic seeding, duplicate handling, and zero-termination toggle
- add CLI tests verifying output against golden fixtures and zero-termination behavior

## Testing
- `node tests/parseQuickHashGenInput.test.js && node tests/search.test.js && node tests/cli.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68aecb93a7108332bfa5935fa05a846d