### PR TITLE
Use textContent for hash display

### DIFF
--- a/QuickHashGenApp.js
+++ b/QuickHashGenApp.js
@@ -328,11 +328,11 @@ function resetSearch() {
                         elements.evalTest && elements.evalTest.checked,
                         currentSeed,
                 );
-                elements.hashes.innerHTML = "";
-                elements.testedCount.innerHTML = "0";
-                elements.solutionsCount.innerHTML = "0";
-                elements.complexity.innerHTML = "?";
-                elements.tableSize.innerHTML = "?";
+                elements.hashes.textContent = "";
+                elements.testedCount.textContent = "0";
+                elements.solutionsCount.textContent = "0";
+                elements.complexity.textContent = "?";
+                elements.tableSize.textContent = "?";
         }
 }
 function updateCodeMetadata() {
@@ -408,8 +408,8 @@ function updateOutput() {
                                 " (" +
                                 best.hashes[i] +
                                 ")\n";
-                elements.hashes.innerHTML = s;
-        } else elements.hashes.innerHTML = "";
+                elements.hashes.textContent = s;
+        } else elements.hashes.textContent = "";
         updateModeLabel();
 }
 function intervalFunction() {


### PR DESCRIPTION
## Summary
- render hashes and counters using `textContent` instead of `innerHTML`
- remove remaining `innerHTML` assignments to prevent HTML injection

## Testing
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aecc2643c88332bce8fe538228e776