### PR TITLE
Fix parseCString handling of trailing backslashes

### DIFF
--- a/QuickHashGenCore.js
+++ b/QuickHashGenCore.js
@@ -75,6 +75,7 @@ function parseCString(s) {
 
 	while (i < s.length && s[i] !== endChar && s[i] !== '\r' && s[i] !== '\n') {
 		if (s[i] === '\\') {
+			if (i + 1 >= s.length) throw new Error("Unterminated C escape sequence");
 			o += s.substring(b, i);
 			var c = s[i + 1];
 			i += 2;
@@ -83,24 +84,24 @@ function parseCString(s) {
 			else {
 				b = i;
 				switch (c) {
-					case '\r': if (s[i] === '\n') ++i; break;
+					case '\r': if (i < s.length && s[i] === '\n') ++i; break;
 					case '\n': break;
 
 					case 'u':
-						while ("0123456789abcdefABCDEF".indexOf(s[i]) >= 0 && i < b + 4) ++i;
+						while (i < s.length && "0123456789abcdefABCDEF".indexOf(s[i]) >= 0 && i < b + 4) ++i;
 						if (i !== b + 4) throw new Error("Illegal C escape sequence");
 						o += String.fromCharCode(parseInt(s.substring(b, i), 16));
 						break;
 
 					case 'x':
-						while ("0123456789abcdefABCDEF".indexOf(s[i]) >= 0) ++i;
+						while (i < s.length && "0123456789abcdefABCDEF".indexOf(s[i]) >= 0) ++i;
 						if (i === b) throw new Error("Illegal C escape sequence");
 						o += String.fromCharCode(parseInt(s.substring(b, i), 16));
 						break;
-					
+
 					default:
 						b = --i;
-						while ("01234567".indexOf(s[i]) >= 0 && i < b + 3) ++i;
+						while (i < s.length && "01234567".indexOf(s[i]) >= 0 && i < b + 3) ++i;
 						if (i === b) throw new Error("Illegal C escape sequence");
 						o += String.fromCharCode(parseInt(s.substring(b, i), 8));
 						break;

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,7 @@
 set -e
 
 node tests/parseQuickHashGenInput.test.js
+node tests/parseCString.test.js
 
 node QuickHashGenCLI.js --seed 1 --tests 100 tests/input1.txt > tests/out1.c
 # invalid option values should print usage and fail

--- a/tests/parseCString.test.js
+++ b/tests/parseCString.test.js
@@ -1,0 +1,7 @@
+const assert = require('assert');
+const core = require('../QuickHashGenCore');
+
+const input = '"' + '\\';
+assert.throws(() => core.parseCString(input), /Unterminated C escape sequence/);
+console.log('parseCString trailing backslash test passed');
+


### PR DESCRIPTION
## Summary
- ensure `parseCString` checks bounds before processing escape sequences
- guard escape parsing loops against reading past the end of the string
- add unit test for trailing backslash escapes
- use tabs for `parseCString` indentation to match project style

## Testing
- `sh test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aecc0540a88332a0d56e211554eec7