### PR TITLE
Introduce cost-based selection for hash expressions

### DIFF
--- a/QuickHashGen.html
+++ b/QuickHashGen.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<title>QuickHashGen – Minimal</title>
+		<title>QuickHashGen</title>
 		<style>
 			:root {
 				color-scheme: dark;
@@ -78,7 +78,7 @@
 		</style>
 	</head>
 	<body>
-		<h1>QuickHashGen – Minimal</h1>
+		<h1>QuickHashGen</h1>
 		<textarea id="editor" rows="18" cols="90" autofocus>
 enter
 one

--- a/QuickHashGenApp.js
+++ b/QuickHashGenApp.js
@@ -454,7 +454,9 @@ function intervalFunction() {
 						best === null ||
 						found.complexity < best.complexity ||
 						(found.complexity === best.complexity &&
-							found.table.length < best.table.length)
+							(found.cost < best.cost ||
+								(found.cost === best.cost &&
+									found.table.length < best.table.length)))
 					) {
 						best = found;
 						updateOutput();

--- a/QuickHashGenCLI.js
+++ b/QuickHashGenCLI.js
@@ -123,7 +123,9 @@ while (qh.getTestedCount() < opts.tests) {
 		(best === null ||
 			found.complexity < best.complexity ||
 			(found.complexity === best.complexity &&
-				found.table.length < best.table.length))
+				(found.cost < best.cost ||
+					(found.cost === best.cost &&
+						found.table.length < best.table.length))))
 	) {
 		best = found;
 		if (best.complexity === 1) break;
@@ -166,7 +168,9 @@ if (opts.bench) {
 				(bestBench === null ||
 					found.complexity < bestBench.complexity ||
 					(found.complexity === bestBench.complexity &&
-						found.table.length < bestBench.table.length))
+						(found.cost < bestBench.cost ||
+							(found.cost === bestBench.cost &&
+								found.table.length < bestBench.table.length))))
 			) {
 				bestBench = found;
 				if (bestBench.complexity === 1) break;

--- a/QuickHashGenCore.js
+++ b/QuickHashGenCore.js
@@ -382,6 +382,7 @@ function QuickHashGen(
 				fn: function (n, w) {
 					return n | 0;
 				},
+				cost: 16,
 			};
 		}
 		function leaf_const() {
@@ -394,6 +395,7 @@ function QuickHashGen(
 				fn: function () {
 					return k;
 				},
+				cost: 8,
 			};
 		}
 		function leaf_w_in() {
@@ -405,6 +407,7 @@ function QuickHashGen(
 				fn: function (n, w) {
 					return w[idx] | 0;
 				},
+				cost: 32,
 			};
 		}
 		function leaf_w_out() {
@@ -417,6 +420,7 @@ function QuickHashGen(
 				fn: function (n, w) {
 					return w[i] | 0;
 				},
+				cost: 48,
 			};
 		}
 		function needsPar(a, prec) {
@@ -428,7 +432,7 @@ function QuickHashGen(
 		function wrapJ(a, prec) {
 			return needsPar(a, prec) ? "(" + a.js + ")" : a.js;
 		}
-		function bin(a, b, op, prec, evalFn) {
+		function bin(a, b, op, prec, evalFn, opCost) {
 			var cLeft = wrapC(a, prec);
 			var needRightPar = op === "-" && b.prec === prec;
 			var cRight = needRightPar ? "(" + b.c + ")" : wrapC(b, prec);
@@ -443,6 +447,7 @@ function QuickHashGen(
 				fn: function (n, w) {
 					return evalFn(a.fn(n, w), b.fn(n, w));
 				},
+				cost: a.cost + b.cost + opCost,
 			};
 		}
 		// Shifts in the generated expressions need to behave identically
@@ -451,7 +456,7 @@ function QuickHashGen(
 		// Using JavaScript's arithmetic ">>" caused discrepancies
 		// between the JS verification and the generated C program for
 		// certain inputs.
-		function sh(a, dir, shamt) {
+		function sh(a, dir, shamt, opCost) {
 			var j, c;
 			if (dir === "<<") {
 				j = wrapJ(a, 1) + " << " + shamt;
@@ -464,6 +469,7 @@ function QuickHashGen(
 						var v = a.fn(n, w) | 0;
 						return (v << shamt) | 0;
 					},
+					cost: a.cost + opCost,
 				};
 			} else {
 				j = wrapJ(a, 1) + " >>> " + shamt;
@@ -476,10 +482,11 @@ function QuickHashGen(
 						var v = a.fn(n, w) | 0;
 						return (v >>> shamt) | 0;
 					},
+					cost: a.cost + opCost,
 				};
 			}
 		}
-		function mul(a, b) {
+		function mul(a, b, opCost) {
 			var c = wrapC(a, 3) + " * " + wrapC(b, 3);
 			var j = "Math.imul(" + a.js + ", " + b.js + ")";
 			return {
@@ -489,11 +496,12 @@ function QuickHashGen(
 				fn: function (n, w) {
 					return Math.imul(a.fn(n, w), b.fn(n, w));
 				},
+				cost: a.cost + b.cost + opCost,
 			};
 		}
 		var OPS = [
 			[
-				4,
+				16,
 				1,
 				1,
 				function () {
@@ -501,7 +509,7 @@ function QuickHashGen(
 				},
 			],
 			[
-				4,
+				8,
 				1,
 				1,
 				function () {
@@ -509,7 +517,7 @@ function QuickHashGen(
 				},
 			],
 			[
-				4,
+				32,
 				1,
 				1,
 				function () {
@@ -517,7 +525,7 @@ function QuickHashGen(
 				},
 			],
 			[
-				4,
+				48,
 				2,
 				2,
 				function () {
@@ -531,7 +539,7 @@ function QuickHashGen(
 				function (c) {
 					var a = rndExpr(c - 1, 1);
 					var shv = (rnd.nextInt(31) + 1) | 0;
-					return sh(a, "<<", shv);
+					return sh(a, "<<", shv, 1);
 				},
 			],
 			[
@@ -541,7 +549,7 @@ function QuickHashGen(
 				function (c) {
 					var a = rndExpr(c - 1, 1);
 					var shv = (rnd.nextInt(31) + 1) | 0;
-					return sh(a, ">>", shv);
+					return sh(a, ">>", shv, 1);
 				},
 			],
 			[
@@ -552,9 +560,16 @@ function QuickHashGen(
 					var b = rnd.nextInt(c - 1) + 1;
 					var L = rndExpr(b, 2),
 						R = rndExpr(c - b, 2);
-					return bin(L, R, "+", 2, function (x, y) {
-						return (x + y) | 0;
-					});
+					return bin(
+						L,
+						R,
+						"+",
+						2,
+						function (x, y) {
+							return (x + y) | 0;
+						},
+						2,
+					);
 				},
 			],
 			[
@@ -565,33 +580,47 @@ function QuickHashGen(
 					var b = rnd.nextInt(c - 1) + 1;
 					var L = rndExpr(b, 2),
 						R = rndExpr(c - b, 3);
-					return bin(L, R, "-", 2, function (x, y) {
-						return (x - y) | 0;
-					});
+					return bin(
+						L,
+						R,
+						"-",
+						2,
+						function (x, y) {
+							return (x - y) | 0;
+						},
+						2,
+					);
 				},
 			],
 			[
-				0,
+				1,
 				2,
 				Infinity,
 				function (c) {
 					var b = rnd.nextInt(c - 1) + 1;
 					var L = rndExpr(b, 0),
 						R = rndExpr(c - b, 0);
-					return bin(L, R, "^", 0, function (x, y) {
-						return (x ^ y) | 0;
-					});
+					return bin(
+						L,
+						R,
+						"^",
+						0,
+						function (x, y) {
+							return (x ^ y) | 0;
+						},
+						1,
+					);
 				},
 			],
 			[
-				3,
+				4,
 				2,
 				Infinity,
 				function (c) {
 					var b = rnd.nextInt(c - 1) + 1;
 					var L = rndExpr(b, 3),
 						R = rndExpr(c - b, 3);
-					return mul(L, R);
+					return mul(L, R, 4);
 				},
 			],
 		];
@@ -613,6 +642,7 @@ function QuickHashGen(
 			fn: function (n, w) {
 				return root.fn(n, w) | 0;
 			},
+			cost: root.cost,
 		};
 	}
 
@@ -653,6 +683,7 @@ function QuickHashGen(
 				false,
 			);
 			var expr = exprObj.js;
+			var exprCost = exprObj.cost;
 			if (complexity >= 4 || !(expr in tried[complexity])) {
 				if (complexity < 4) {
 					tried[complexity][expr] = true;
@@ -705,6 +736,7 @@ function QuickHashGen(
 					}
 					var result = {
 						complexity: complexity,
+						cost: exprCost,
 						prng: prngCopy,
 						table: table,
 						hashes: hashes,

--- a/README.md
+++ b/README.md
@@ -19,30 +19,30 @@ node QuickHashGenCLI.js [options] [input-file]
 
 Options:
 
-- `-h`, `--help` &ndash; display usage information.
-- `--tests N` &ndash; number of expressions to try (default `100000`). A larger value
+- `-h`, `--help`: display usage information.
+- `--tests N`: number of expressions to try (default `100000`). A larger value
   increases the search space and the odds of discovering a lower-complexity hash
   at the cost of longer runtime.
-- `--no-multiplications` &ndash; disallow multiplication instructions in the generated
+- `--no-multiplications`: disallow multiplication instructions in the generated
   hash expression. Useful for targets where multiplies are expensive or
   unavailable.
-- `--no-length` &ndash; prevent use of the string length variable `n` in the hash
+- `--no-length`: prevent use of the string length variable `n` in the hash
   expression. This keeps the hash based strictly on character data so strings of
   differing lengths don't simply hash to their length. The generated lookup still
   receives `n` for bounds checking.
-- `--no-zero-termination` &ndash; generate a lookup function that does not require the
+- `--no-zero-termination`: generate a lookup function that does not require the
   input strings to be zero-terminated. The resulting C template uses `strncmp`
   and expects the caller to supply the string length.
-- `--eval-test` &ndash; after a candidate expression is found, evaluate it on all input
+- `--eval-test`: after a candidate expression is found, evaluate it on all input
   strings using the selected engine to verify that it maps each string to the
   expected index. Adds runtime but provides a safety check when modifying the
   algorithm.
-- `--force-eval` &ndash; use the `eval` engine instead of the default `Function`
+- `--force-eval`: use the `eval` engine instead of the default `Function`
   constructor when searching and testing. Mirrors the HTML interface’s "Use eval
   engine" checkbox and can influence performance depending on the environment.
-- `--bench` &ndash; run a simple benchmark comparing the `Function` constructor and
+- `--bench`: run a simple benchmark comparing the `Function` constructor and
   `eval` engines after a solution is found.
-- `--seed N` &ndash; seed all internal randomness with a single 32-bit value for
+- `--seed N`: seed all internal randomness with a single 32-bit value for
   fully deterministic output.
 
 ### Input formats
@@ -155,33 +155,59 @@ console.log(cExpr);
 `QuickHashGenCore.js` exports a handful of helpers and the `QuickHashGen`
 class for programmatic integration:
 
-- **`QuickHashGen`** – the core search engine. The constructor accepts
+- **`QuickHashGen`**: the core search engine. The constructor accepts
   `(strings, minTableSize, maxTableSize, zeroTerminated,
 allowMultiplication, allowLength, useEvalEngine=false,
 evalTest=false, seed0?, seed1?)`.
   If `seed0` is omitted the PRNG is seeded randomly; providing `seed0`
   (and optionally `seed1`) yields deterministic output.
   Methods include:
-  - `search(complexity, iterations)` – explore random expressions and return
+  - `search(complexity, iterations)`: explore random expressions and return
     the first collision-free solution or `null`.
-  - `getTestedCount()` – total number of expressions evaluated so far.
-  - `randomInt(max)` – draw a pseudo-random integer in `[0, max)`.
-  - `generateCExpression(solution)` – build a C hash expression string.
-  - `generateJSExpression(solution)` – build a JavaScript hash expression string.
-  - `generateJSEvaluator(solution)` – build a CSP‑safe evaluator function.
-  - `generateCOutput(template, solution)` – populate a C template using a
+  - `getTestedCount()`: total number of expressions evaluated so far.
+  - `randomInt(max)`: draw a pseudo-random integer in `[0, max)`.
+  - `generateCExpression(solution)`: build a C hash expression string.
+  - `generateJSExpression(solution)`: build a JavaScript hash expression string.
+  - `generateJSEvaluator(solution)`: build a CSP-safe evaluator function.
+  - `generateCOutput(template, solution)`: populate a C template using a
     solution object returned by `search` (internally uses `generateCExpression`).
-- **`parseQuickHashGenInput(text)`** – parse newline or C‑style quoted
+- **`parseQuickHashGenInput(text)`**: parse newline or C-style quoted
   strings into an array, mirroring CLI input handling.
 - **`stringListToC(strings, columns, prefix)`** and
-  **`numberListToC(numbers, columns, base, prefix)`** – format arrays as C
+  **`numberListToC(numbers, columns, base, prefix)`**: format arrays as C
   initializers.
-- **`toHex(i, length)`** – format a number as a zero-padded hexadecimal
+- **`toHex(i, length)`**: format a number as a zero-padded hexadecimal
   string.
-- **`parseCString`** / **`escapeCString`** – convert between C‑style quoted
+- **`parseCString`** / **`escapeCString`**: convert between C-style quoted
   strings and raw JavaScript strings.
-- **`XorshiftPRNG2x32`** – deterministic pseudo‑random number generator used
+- **`XorshiftPRNG2x32`**: deterministic pseudo-random number generator used
   during the search.
+
+### Cost model
+
+To break ties between expressions of the same complexity, QuickHashGen
+tracks a simple runtime cost for each abstract syntax tree (AST) node. The
+total cost of an expression is the sum of its node costs, and the search
+prefers solutions with the lowest cost.
+
+Base node costs reflect their relative expense:
+
+- constant value: `8`
+- length variable `n`: `16`
+- character read within the known string length `p[i]`: `32`
+- character read beyond the input length guard `p[i]`: `48`
+
+Binary operators add the cost of their operands plus an operator cost:
+
+- shift (`<<`/`>>>`): `+1`
+- addition or subtraction: `+2`
+- XOR: `+1`
+- multiplication: `+4`
+
+When multiple expressions hash all strings without collisions and have the
+same complexity, the generator chooses the one with the lowest total cost,
+favoring cheaper operations like constants over more expensive character
+lookups.
 
 ### Debug mode
 

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -44,7 +44,9 @@ function findSolution(zeroTerminated) {
 			(best === null ||
 				found.complexity < best.complexity ||
 				(found.complexity === best.complexity &&
-					found.table.length < best.table.length))
+					(found.cost < best.cost ||
+						(found.cost === best.cost &&
+							found.table.length < best.table.length))))
 		) {
 			best = found;
 			if (best.complexity === 1) break;


### PR DESCRIPTION
## Summary
- track a cost metric for each AST node and propagate it through expression generation
- prefer lower-cost solutions when searching for hash expressions in CLI, browser app, and tests
- document and clarify the cost model in the README with colon-based descriptions
- keep sample HTML title as just "QuickHashGen" and restore legacy demo unchanged
- format code with Prettier using tab indentation
- avoid dash-minus confusion by using colon separators in documentation
- raise base costs to 8/16/32/48 and operator costs to shift 1, add/sub 2, xor 1, mul 4

## Testing
- `npx prettier --write --use-tabs QuickHashGenCore.js README.md`
- `bash test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aed5f4f92c8332beb69c3ca4dfdc27