### PR TITLE
Introduce cost-based selection for hash expressions

### DIFF
--- a/QuickHashGen.html
+++ b/QuickHashGen.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<title>QuickHashGen – Minimal</title>
+		<title>QuickHashGen</title>
 		<style>
 			:root {
 				color-scheme: dark;
@@ -78,7 +78,7 @@
 		</style>
 	</head>
 	<body>
-		<h1>QuickHashGen – Minimal</h1>
+		<h1>QuickHashGen</h1>
 		<textarea id="editor" rows="18" cols="90" autofocus>
 enter
 one
@@ -107,7 +107,8 @@ line
 		<div class="stats">
 			Tested <span id="testedCount">0</span> expressions. Found
 			<span id="solutionsCount">0</span> solutions. Complexity:
-			<span id="complexity">?</span>, table size: <span id="tableSize">?</span>.
+			<span id="complexity">?</span>, cost: <span id="cost">?</span>, table
+			size: <span id="tableSize">?</span>.
 			<div id="testStatus" class="small"></div>
 		</div>
 		<pre id="hashes"></pre>

--- a/QuickHashGenApp.js
+++ b/QuickHashGenApp.js
@@ -37,6 +37,7 @@ var HTML_ELEMENTS = [
 	"editor",
 	"solutionsCount",
 	"complexity",
+	"cost",
 	"tableSize",
 	"testedCount",
 	"requireZeroTermination",
@@ -354,6 +355,7 @@ function resetSearch() {
 		elements.testedCount.textContent = "0";
 		elements.solutionsCount.textContent = "0";
 		elements.complexity.textContent = "?";
+		elements.cost.textContent = "?";
 		elements.tableSize.textContent = "?";
 	}
 }
@@ -454,7 +456,9 @@ function intervalFunction() {
 						best === null ||
 						found.complexity < best.complexity ||
 						(found.complexity === best.complexity &&
-							found.table.length < best.table.length)
+							(found.cost < best.cost ||
+								(found.cost === best.cost &&
+									found.table.length < best.table.length)))
 					) {
 						best = found;
 						updateOutput();
@@ -465,6 +469,7 @@ function intervalFunction() {
 			elements.testedCount.textContent = theHashMaker.getTestedCount();
 			elements.solutionsCount.textContent = solutionsCounter;
 			elements.complexity.textContent = best === null ? "?" : best.complexity;
+			elements.cost.textContent = best === null ? "?" : best.cost;
 			elements.tableSize.textContent = best === null ? "?" : best.table.length;
 		}
 	} catch (err) {

--- a/QuickHashGenCLI.js
+++ b/QuickHashGenCLI.js
@@ -123,7 +123,9 @@ while (qh.getTestedCount() < opts.tests) {
 		(best === null ||
 			found.complexity < best.complexity ||
 			(found.complexity === best.complexity &&
-				found.table.length < best.table.length))
+				(found.cost < best.cost ||
+					(found.cost === best.cost &&
+						found.table.length < best.table.length))))
 	) {
 		best = found;
 		if (best.complexity === 1) break;
@@ -166,7 +168,9 @@ if (opts.bench) {
 				(bestBench === null ||
 					found.complexity < bestBench.complexity ||
 					(found.complexity === bestBench.complexity &&
-						found.table.length < bestBench.table.length))
+						(found.cost < bestBench.cost ||
+							(found.cost === bestBench.cost &&
+								found.table.length < bestBench.table.length))))
 			) {
 				bestBench = found;
 				if (bestBench.complexity === 1) break;

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -44,7 +44,9 @@ function findSolution(zeroTerminated) {
 			(best === null ||
 				found.complexity < best.complexity ||
 				(found.complexity === best.complexity &&
-					found.table.length < best.table.length))
+					(found.cost < best.cost ||
+						(found.cost === best.cost &&
+							found.table.length < best.table.length))))
 		) {
 			best = found;
 			if (best.complexity === 1) break;


### PR DESCRIPTION
## Summary
- track a cost metric for each AST node and propagate it through expression generation
- prefer lower-cost solutions when searching for hash expressions in CLI, browser app, and tests
- document and clarify the cost model in the README with colon-based descriptions
- keep sample HTML title as just "QuickHashGen" and restore legacy demo unchanged
- format code with Prettier using tab indentation
- avoid dash-minus confusion by using colon separators in documentation
- raise base costs to 8/16/32/48 and operator costs to shift 1, add/sub 2, xor 1, mul 4
- add table-size penalty (+16 per power of two) to total cost metric
- display total cost in the web interface

## Testing
- `npx prettier --write --use-tabs QuickHashGen.html QuickHashGenApp.js`
- `bash test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aed5f4f92c8332beb69c3ca4dfdc27