### PR TITLE
Track more expressions and pick lowest-cost solutions

### DIFF
--- a/QuickHashGenApp.js
+++ b/QuickHashGenApp.js
@@ -454,11 +454,8 @@ function intervalFunction() {
 				if (found !== null) {
 					if (
 						best === null ||
-						found.complexity < best.complexity ||
-						(found.complexity === best.complexity &&
-							(found.cost < best.cost ||
-								(found.cost === best.cost &&
-									found.table.length < best.table.length)))
+						found.cost < best.cost ||
+						(found.cost === best.cost && found.table.length < best.table.length)
 					) {
 						best = found;
 						updateOutput();

--- a/QuickHashGenCLI.js
+++ b/QuickHashGenCLI.js
@@ -121,11 +121,8 @@ while (qh.getTestedCount() < opts.tests) {
 	if (
 		found &&
 		(best === null ||
-			found.complexity < best.complexity ||
-			(found.complexity === best.complexity &&
-				(found.cost < best.cost ||
-					(found.cost === best.cost &&
-						found.table.length < best.table.length))))
+			found.cost < best.cost ||
+			(found.cost === best.cost && found.table.length < best.table.length))
 	) {
 		best = found;
 		if (best.complexity === 1) break;
@@ -166,11 +163,9 @@ if (opts.bench) {
 			if (
 				found &&
 				(bestBench === null ||
-					found.complexity < bestBench.complexity ||
-					(found.complexity === bestBench.complexity &&
-						(found.cost < bestBench.cost ||
-							(found.cost === bestBench.cost &&
-								found.table.length < bestBench.table.length))))
+					found.cost < bestBench.cost ||
+					(found.cost === bestBench.cost &&
+						found.table.length < bestBench.table.length))
 			) {
 				bestBench = found;
 				if (bestBench.complexity === 1) break;

--- a/QuickHashGenCore.js
+++ b/QuickHashGenCore.js
@@ -666,7 +666,7 @@ function QuickHashGen(
 			);
 		}
 		if (!(complexity in tried)) {
-			tried[complexity] = {};
+			tried[complexity] = Object.create(null);
 		}
 
 		var stringsCount = strings.length;
@@ -684,8 +684,8 @@ function QuickHashGen(
 			);
 			var expr = exprObj.js;
 			var exprCost = exprObj.cost;
-			if (complexity >= 4 || !(expr in tried[complexity])) {
-				if (complexity < 4) {
+			if (complexity > 4 || !(expr in tried[complexity])) {
+				if (complexity <= 4) {
 					tried[complexity][expr] = true;
 				}
 				var func;

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Options:
 
 - `-h`, `--help`: display usage information.
 - `--tests N`: number of expressions to try (default `100000`). A larger value
-  increases the search space and the odds of discovering a lower-complexity hash
-  at the cost of longer runtime.
+  increases the search space and the odds of discovering a lower-cost hash at
+  the cost of longer runtime.
 - `--no-multiplications`: disallow multiplication instructions in the generated
   hash expression. Useful for targets where multiplies are expensive or
   unavailable.
@@ -185,10 +185,9 @@ evalTest=false, seed0?, seed1?)`.
 
 ### Cost model
 
-To break ties between expressions of the same complexity, QuickHashGen
-tracks a simple runtime cost for each abstract syntax tree (AST) node. The
-total cost combines these node costs with a penalty for the hash table size,
-and the search prefers solutions with the lowest cost.
+QuickHashGen tracks a simple runtime cost for each abstract syntax tree (AST)
+node. The total cost combines these node costs with a penalty for the hash
+table size, and the search prefers solutions with the lowest cost.
 
 Base node costs reflect their relative expense:
 
@@ -207,10 +206,9 @@ Binary operators add the cost of their operands plus an operator cost:
 Hash table size also adds to the total cost: each power-of-two increase adds
 `16`. For example, a table with `256` entries (`2^8`) contributes `128`.
 
-When multiple expressions hash all strings without collisions and have the
-same complexity, the generator chooses the one with the lowest total cost,
-favoring cheaper operations like constants over more expensive character
-lookups and large tables.
+When multiple expressions hash all strings without collisions, the generator
+chooses the one with the lowest total cost, favoring cheaper operations like
+constants over more expensive character lookups and large tables.
 
 ### Debug mode
 

--- a/tests/golden1.c
+++ b/tests/golden1.c
@@ -4,12 +4,11 @@ static int lookup(int n /* string length */, const char* s /* string (zero termi
 	static const char* STRINGS[3] = {
 		"red", "green", "blue"
 	};
-	static const int HASH_TABLE[32] = {
-		-1, -1, -1, -1, 0, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 
-		-1, -1, -1, -1, -1, 2, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
+	static const int HASH_TABLE[4] = {
+		2, 1, -1, 0
 	};
 	const unsigned char* p = (const unsigned char*) s;
 	if (n < 3 || n > 5) return -1;
-	int stringIndex = HASH_TABLE[(p[2]) & 31u];
+	int stringIndex = HASH_TABLE[(n) & 3u];
 	return (stringIndex >= 0 && strcmp(s, STRINGS[stringIndex]) == 0) ? stringIndex : -1;
 }

--- a/tests/golden4.c
+++ b/tests/golden4.c
@@ -8,12 +8,11 @@ static int lookup(int n /* string length */, const char* s /* string (zero termi
 		"abcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyzabcxyz", 
 		"01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567"
 	};
-	static const int HASH_TABLE[32] = {
-		-1, -1, -1, -1, -1, -1, 1, 0, -1, 4, -1, 3, -1, -1, -1, -1, 
-		-1, -1, -1, -1, -1, -1, -1, -1, -1, 2, -1, -1, -1, -1, -1, -1
+	static const int HASH_TABLE[16] = {
+		1, 2, -1, -1, -1, -1, -1, 4, -1, 3, -1, -1, -1, -1, -1, 0
 	};
 	const unsigned char* p = (const unsigned char*) s;
 	if (n < 128 || n > 240) return -1;
-	int stringIndex = HASH_TABLE[(p[67] - 25u ^ p[127]) & 31u];
+	int stringIndex = HASH_TABLE[(((0u + 24u) >> 27 ^ p[127]) + p[51] + 31u) & 15u];
 	return (stringIndex >= 0 && strcmp(s, STRINGS[stringIndex]) == 0) ? stringIndex : -1;
 }

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -42,11 +42,8 @@ function findSolution(zeroTerminated) {
 		if (
 			found &&
 			(best === null ||
-				found.complexity < best.complexity ||
-				(found.complexity === best.complexity &&
-					(found.cost < best.cost ||
-						(found.cost === best.cost &&
-							found.table.length < best.table.length))))
+				found.cost < best.cost ||
+				(found.cost === best.cost && found.table.length < best.table.length))
 		) {
 			best = found;
 			if (best.complexity === 1) break;


### PR DESCRIPTION
## Summary
- Avoid duplicate expressions through complexity 4 using prototype-less tracking
- Select the best hash purely by cost in the browser and CLI
- Refresh README and tests for the cost-first strategy

## Testing
- `npx prettier --write --use-tabs .`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68af01ccd6308332a577d770597cf2ad