### PR TITLE
Add copy button to HTML UI

### DIFF
--- a/QuickHashGen.html
+++ b/QuickHashGen.html
@@ -89,6 +89,7 @@ line
 		>
 		<div class="controls">
 			<button id="startStop" onclick="toggleRun()">Start</button>
+			<button id="copyButton" onclick="copyHashes()">Copy</button>
 			<label><input id="allowMultiplications" type="checkbox" checked />Allow Multiplications</label>
 			<label
 				><input

--- a/QuickHashGenApp.js
+++ b/QuickHashGenApp.js
@@ -26,6 +26,7 @@ var HTML_ELEMENTS = [
 	"forceEval",
 	"hashes",
 	"startStop",
+	"copyButton",
 	"testStatus",
 ];
 var elements = {};
@@ -126,6 +127,25 @@ function toggleRun() {
 	updateCodeMetadata(); // sync STRINGS length and min/max guard
 }
 window.toggleRun = toggleRun; // expose for inline onclick
+
+function copyHashes() {
+	try {
+		var text = elements.hashes && elements.hashes.textContent ? elements.hashes.textContent : "";
+		if (navigator.clipboard && navigator.clipboard.writeText) {
+			navigator.clipboard.writeText(text);
+		} else {
+			var t = document.createElement("textarea");
+			t.value = text;
+			document.body.appendChild(t);
+			t.select();
+			document.execCommand("copy");
+			document.body.removeChild(t);
+		}
+	} catch (err) {
+		console.error("Copy failed", err);
+	}
+}
+window.copyHashes = copyHashes;
 function parseStringsFromEditor(text) {
 	var p = text.indexOf("STRINGS");
 	if (p >= 0) {


### PR DESCRIPTION
## Summary
- Add Copy button to HTML interface to allow copying generated hashes
- Implement clipboard logic in QuickHashGenApp.js with fallback support

## Testing
- `bash tests/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b5852c73088332aca0b40829ef91f9